### PR TITLE
Remediate pg documentation authority audit findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ __pycache__/
 # -------------
 test-results.txt
 CLAUDE.md
+AGENTS.md
+strict-audit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Startup
+
+This repository operates under the platform contract.
+
+Read first:
+
+../platform-docs/_platform/PLATFORM_OPERATING_MODEL.md
+../platform-docs/_platform/REPO_TAXONOMY.md
+../platform-docs/_platform/ARCHITECTURAL_DOCTRINE_TIER0.md
+../platform-docs/_platform/CONTRACT_SCHEMA.md
+../platform-docs/_platform/CONTRACT_VALIDATION.md
+../platform-docs/_platform/LIFECYCLE_MODEL.md
+../platform-docs/_platform/GENERATOR_MODEL.md
+../platform-docs/_platform/PR_WORKFLOW.md
+
+Authority constraints:
+
+- No kubectl access.
+- Any kubectl steps must be labeled: **Run manually by human**.
+
+Before editing, classify repo scope using `REPO_TAXONOMY.md` and determine whether changes are single-repo or cross-repo.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project demonstrates a hardened, production-grade approach to running multiple tenants on a single PostgreSQL server while maintaining strict, testable isolation between tenants. The model is designed to be portable from local Docker development environments to AWS RDS PostgreSQL and Aurora PostgreSQL.
 
+Repository Category: `platform-service` (see `platform-docs/_platform/REPO_TAXONOMY.md`)
+
 The primary motivations are:
 1. Reduce infrastructure cost by consolidating tenant databases into a single RDS instance.
 2. Maintain strong tenant data isolation through PostgreSQL-native security controls.
@@ -104,6 +106,7 @@ The script reports success or failure for each test and summarizes total failure
 ## Documentation
 
 Detailed design, security, and compliance documentation is available under `docs/`.
+Platform-wide governance, contract schema, lifecycle, and doctrine remain authoritative in `platform-docs/_platform/`.
 
 - `docs/ARCHITECTURE.md`  
   High-level design of the multi-tenant PostgreSQL model.
@@ -150,13 +153,13 @@ Planned next steps include:
    The PostgreSQL provider will then target the RDS endpoint to apply the same tenant isolation model used in the local Docker environment.
 
 3. CI/CD Integration  
-   Use GitLab CI/CD to:
+   Use GitHub Actions and shared platform workflows to:
    - Run the Docker-based isolation tests on each merge request
    - Execute Terraform `plan` for review
    - Execute Terraform `apply` on protected branches
    - Optionally run a post-deploy verification test suite against RDS
 
-4. pgAudit Integra
+4. pgAudit Integration
 
 -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add `AGENTS.md` and align agent startup references to current platform contract docs
- add explicit repository category to README
- clarify docs authority boundary (capability docs local, governance in `platform-docs/_platform/`)
- ignore local `strict-audit` artifact in `.gitignore`

## Testing
- docs-only changes; no runtime tests required