### PR TITLE
Add shared PostgreSQL provisioning workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Admin and tenant behavior is validated through a comprehensive test suite.
 
 For real external-host provisioning, see:
 
-- [`docs/PROVISIONING.md`](/Users/xavierlopez/Dev/pg/docs/PROVISIONING.md)
-- [`scripts/provision_tenant.sh`](/Users/xavierlopez/Dev/pg/scripts/provision_tenant.sh)
+- `docs/PROVISIONING.md`
+- `scripts/provision_tenant.sh`
 
 -----------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository includes:
 - A hardened tenant isolation model (database-per-tenant, role-per-tenant, dedicated schema, locked-down public schema, safe search_path, and default privilege hardening)
 - A reproducible Docker environment
 - A comprehensive test suite including both happy-path and negative “attack” tests
+- A host-targeted provisioning workflow for external shared PostgreSQL
 - Architectural, security, compliance, and auditing documentation
 - A roadmap toward Terraform implementation and RDS deployment
 
@@ -28,9 +29,11 @@ pg-multitenant/
 │   └── 01_init_tenants.sql
 ├── scripts/
 │   ├── test_isolation.sh
+│   ├── provision_tenant.sh
 │   └── (future) test_isolation_rds.sh
 ├── docs/
 │   ├── ARCHITECTURE.md
+│   ├── PROVISIONING.md
 │   ├── SECURITY.md
 │   ├── THREAT_MODEL.md
 │   ├── COMPLIANCE.md
@@ -57,6 +60,11 @@ Each tenant receives:
 - No ability to create extensions or foreign data wrappers
 
 Admin and tenant behavior is validated through a comprehensive test suite.
+
+For real external-host provisioning, see:
+
+- [`docs/PROVISIONING.md`](/Users/xavierlopez/Dev/pg/docs/PROVISIONING.md)
+- [`scripts/provision_tenant.sh`](/Users/xavierlopez/Dev/pg/scripts/provision_tenant.sh)
 
 -----------------------------------------------------------------------
 
@@ -141,14 +149,14 @@ These documents serve as a reference implementation for building secure, complia
 Planned next steps include:
 
 1. Terraform Migration  
-   Convert the database initialization logic (currently in SQL) into Terraform resources using the Terraform **PostgreSQL provider**, including:
+   Convert the host-targeted provisioning logic into Terraform resources using the Terraform **PostgreSQL provider**, including:
    - `postgresql_database`
    - `postgresql_role`
    - `postgresql_schema`
    - `postgresql_grant`
    - `postgresql_default_privileges`
 
-   These resources will allow Terraform to connect directly to a PostgreSQL instance (initially your local Docker instance, later AWS RDS) and create tenant databases, roles, schemas, and hardened privileges in a fully declarative manner.
+   These resources will allow Terraform to connect directly to a PostgreSQL instance (initially the shared VM, later managed PostgreSQL) and create tenant databases, roles, schemas, and hardened privileges in a fully declarative manner.
 
 2. AWS Deployment  
    Introduce AWS infrastructure using Terraform’s `aws` provider:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,12 @@ AWS deployment (future, via Terraform):
   - grants (`postgresql_grant`)
 - The same logical design is applied to RDS using infrastructure-as-code rather than init scripts.
 
+Current platform direction:
+
+- the PostgreSQL host itself is provisioned outside this repo
+- this repo owns tenant-level PostgreSQL provisioning on that host
+- tenant workloads consume only Vault-delivered connection outputs
+
 ## Data Isolation Summary
 
 Data isolation is achieved through:

--- a/docs/PROVISIONING.md
+++ b/docs/PROVISIONING.md
@@ -36,7 +36,7 @@ It does not:
 
 The first provisioning entry point is:
 
-- [`scripts/provision_tenant.sh`](/Users/xavierlopez/Dev/pg/scripts/provision_tenant.sh)
+- `scripts/provision_tenant.sh`
 
 It targets any reachable PostgreSQL host and applies the hardened tenant model to one tenant at a time.
 
@@ -134,7 +134,7 @@ After provisioning:
 
 The broader negative-test model remains in:
 
-- [`scripts/test_isolation.sh`](/Users/xavierlopez/Dev/pg/scripts/test_isolation.sh)
+- `scripts/test_isolation.sh`
 
 ## First Consumer
 

--- a/docs/PROVISIONING.md
+++ b/docs/PROVISIONING.md
@@ -1,0 +1,145 @@
+# Shared PostgreSQL Provisioning Workflow
+
+## Purpose
+
+This document defines the first real provisioning workflow for the external shared PostgreSQL host.
+
+It is intentionally split from VM provisioning:
+
+- the PostgreSQL VM/host is provisioned by `kubernetes-platform-infrastructure`
+- PostgreSQL internals are provisioned by `pg`
+
+This repository owns:
+- tenant database creation
+- tenant login role creation
+- schema/grant/default privilege hardening
+- tenant-facing secret contract
+
+## Scope
+
+V1 provisioning creates:
+
+- one tenant database
+- one tenant login role
+- one application schema (`app`)
+- database-level `CONNECT` isolation
+- schema/table/sequence hardening
+- role-level operational guardrails
+
+It does not:
+
+- provision the VM
+- write values into Vault automatically
+- onboard every tenant in one step
+
+## Provisioning Entry Point
+
+The first provisioning entry point is:
+
+- [`scripts/provision_tenant.sh`](/Users/xavierlopez/Dev/pg/scripts/provision_tenant.sh)
+
+It targets any reachable PostgreSQL host and applies the hardened tenant model to one tenant at a time.
+
+## Required Inputs
+
+Per run:
+
+- PostgreSQL admin host
+- PostgreSQL admin port
+- PostgreSQL admin user
+- PostgreSQL admin password
+- tenant key
+- database name
+- application role name
+- application role password
+
+Optional inputs:
+
+- platform owner role, default `platform_owner`
+- app schema, default `app`
+- statement timeout, default `3s`
+- lock timeout, default `2s`
+- idle-in-transaction timeout, default `10s`
+- connection limit, default `2`
+
+## Example
+
+```bash
+./scripts/provision_tenant.sh \
+  --admin-host pg-01.internal \
+  --admin-port 5432 \
+  --admin-user postgres \
+  --admin-password 'replace-me' \
+  --tenant-key demo \
+  --database-name db_demo \
+  --app-role demo_app \
+  --app-password 'replace-me'
+```
+
+## What The Script Applies
+
+Against the shared host:
+
+1. Ensures `platform_owner` exists
+2. Creates or updates the tenant login role
+3. Creates the tenant database if missing
+4. Revokes `CONNECT` for `PUBLIC` on the tenant database
+5. Grants `CONNECT` only to the tenant app role
+6. Applies per-role operational guardrails:
+   - `search_path`
+   - `connection_limit`
+   - `lock_timeout`
+   - `idle_in_transaction_session_timeout`
+7. Locks down `public` in the tenant database
+8. Ensures the tenant `app` schema exists and is owned by `platform_owner`
+9. Applies default privileges and runtime grants for tables and sequences
+
+## Tenant Secret Output Contract
+
+Provisioning produces this tenant-facing contract:
+
+- Vault path: `tenants/<tenant>/db`
+
+Required keys:
+
+- `DATABASE_URL`
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+
+Example for tenant `demo`:
+
+```text
+tenants/demo/db
+  DATABASE_URL=postgresql://demo_app:<password>@pg-01.internal:5432/db_demo
+  DB_HOST=pg-01.internal
+  DB_PORT=5432
+  DB_NAME=db_demo
+  DB_USER=demo_app
+  DB_PASSWORD=<password>
+```
+
+`gitops` tenant manifests should consume only this output contract. They should not own database provisioning mechanics.
+
+## Validation Procedure
+
+After provisioning:
+
+1. Connect as the tenant role to the tenant database
+2. Confirm the role can access only its own database
+3. Confirm the role cannot create objects in `public`
+4. Confirm timeouts and connection limits are applied
+
+The broader negative-test model remains in:
+
+- [`scripts/test_isolation.sh`](/Users/xavierlopez/Dev/pg/scripts/test_isolation.sh)
+
+## First Consumer
+
+The first real tenant to consume this workflow will be:
+
+- `panchito`
+
+That onboarding remains tracked separately so the generic provisioning model can stabilize first.

--- a/scripts/provision_tenant.sh
+++ b/scripts/provision_tenant.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/provision_tenant.sh \
+    --admin-host <host> \
+    --admin-port <port> \
+    --admin-user <user> \
+    --admin-password <password> \
+    --tenant-key <tenant_key> \
+    --database-name <database_name> \
+    --app-role <app_role> \
+    --app-password <app_password>
+
+Optional:
+  --platform-owner-role <role>                 Default: platform_owner
+  --app-schema <schema>                        Default: app
+  --statement-timeout <duration>               Default: 3s
+  --lock-timeout <duration>                    Default: 2s
+  --idle-in-tx-timeout <duration>              Default: 10s
+  --connection-limit <number>                  Default: 2
+  --sslmode <mode>                             Default: disable
+
+This script provisions one tenant database and login role on a shared PostgreSQL host.
+It is intentionally host-targeted and does not provision the VM itself.
+EOF
+}
+
+ADMIN_HOST=""
+ADMIN_PORT="5432"
+ADMIN_USER="postgres"
+ADMIN_PASSWORD=""
+TENANT_KEY=""
+DATABASE_NAME=""
+APP_ROLE=""
+APP_PASSWORD=""
+PLATFORM_OWNER_ROLE="platform_owner"
+APP_SCHEMA="app"
+STATEMENT_TIMEOUT="3s"
+LOCK_TIMEOUT="2s"
+IDLE_IN_TX_TIMEOUT="10s"
+CONNECTION_LIMIT="2"
+SSLMODE="disable"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --admin-host)
+      ADMIN_HOST="$2"
+      shift 2
+      ;;
+    --admin-port)
+      ADMIN_PORT="$2"
+      shift 2
+      ;;
+    --admin-user)
+      ADMIN_USER="$2"
+      shift 2
+      ;;
+    --admin-password)
+      ADMIN_PASSWORD="$2"
+      shift 2
+      ;;
+    --tenant-key)
+      TENANT_KEY="$2"
+      shift 2
+      ;;
+    --database-name)
+      DATABASE_NAME="$2"
+      shift 2
+      ;;
+    --app-role)
+      APP_ROLE="$2"
+      shift 2
+      ;;
+    --app-password)
+      APP_PASSWORD="$2"
+      shift 2
+      ;;
+    --platform-owner-role)
+      PLATFORM_OWNER_ROLE="$2"
+      shift 2
+      ;;
+    --app-schema)
+      APP_SCHEMA="$2"
+      shift 2
+      ;;
+    --statement-timeout)
+      STATEMENT_TIMEOUT="$2"
+      shift 2
+      ;;
+    --lock-timeout)
+      LOCK_TIMEOUT="$2"
+      shift 2
+      ;;
+    --idle-in-tx-timeout)
+      IDLE_IN_TX_TIMEOUT="$2"
+      shift 2
+      ;;
+    --connection-limit)
+      CONNECTION_LIMIT="$2"
+      shift 2
+      ;;
+    --sslmode)
+      SSLMODE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_identifier() {
+  local value="$1"
+  local field="$2"
+  if [[ ! "$value" =~ ^[a-z][a-z0-9_]*$ ]]; then
+    echo "Invalid ${field}: '${value}'. Use lowercase letters, numbers, and underscores only." >&2
+    exit 1
+  fi
+}
+
+escape_sql_literal() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+run_psql() {
+  local db_name="$1"
+  local sql="$2"
+
+  PGPASSWORD="$ADMIN_PASSWORD" psql \
+    "host=${ADMIN_HOST} port=${ADMIN_PORT} user=${ADMIN_USER} dbname=${db_name} sslmode=${SSLMODE}" \
+    -v ON_ERROR_STOP=1 <<SQL
+${sql}
+SQL
+}
+
+if [[ -z "$ADMIN_HOST" || -z "$ADMIN_PASSWORD" || -z "$TENANT_KEY" || -z "$DATABASE_NAME" || -z "$APP_ROLE" || -z "$APP_PASSWORD" ]]; then
+  usage >&2
+  exit 1
+fi
+
+require_identifier "$TENANT_KEY" "tenant key"
+require_identifier "$DATABASE_NAME" "database name"
+require_identifier "$APP_ROLE" "app role"
+require_identifier "$PLATFORM_OWNER_ROLE" "platform owner role"
+require_identifier "$APP_SCHEMA" "app schema"
+
+if [[ ! "$CONNECTION_LIMIT" =~ ^[0-9]+$ ]]; then
+  echo "Invalid connection limit: '${CONNECTION_LIMIT}'" >&2
+  exit 1
+fi
+
+APP_PASSWORD_ESCAPED="$(escape_sql_literal "$APP_PASSWORD")"
+STATEMENT_TIMEOUT_ESCAPED="$(escape_sql_literal "$STATEMENT_TIMEOUT")"
+LOCK_TIMEOUT_ESCAPED="$(escape_sql_literal "$LOCK_TIMEOUT")"
+IDLE_IN_TX_TIMEOUT_ESCAPED="$(escape_sql_literal "$IDLE_IN_TX_TIMEOUT")"
+
+echo "Provisioning tenant '${TENANT_KEY}' on ${ADMIN_HOST}:${ADMIN_PORT} ..."
+
+run_psql "postgres" "
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${PLATFORM_OWNER_ROLE}') THEN
+    EXECUTE 'CREATE ROLE ${PLATFORM_OWNER_ROLE} NOLOGIN';
+  END IF;
+END
+\$\$;
+
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${APP_ROLE}') THEN
+    EXECUTE 'CREATE ROLE ${APP_ROLE} LOGIN PASSWORD ''${APP_PASSWORD_ESCAPED}''';
+  ELSE
+    EXECUTE 'ALTER ROLE ${APP_ROLE} LOGIN PASSWORD ''${APP_PASSWORD_ESCAPED}''';
+  END IF;
+END
+\$\$;
+
+SELECT format('CREATE DATABASE %I OWNER %I', '${DATABASE_NAME}', '${ADMIN_USER}')
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM pg_database
+  WHERE datname = '${DATABASE_NAME}'
+)\gexec
+
+REVOKE CONNECT ON DATABASE ${DATABASE_NAME} FROM PUBLIC;
+GRANT CONNECT ON DATABASE ${DATABASE_NAME} TO ${APP_ROLE};
+ALTER DATABASE ${DATABASE_NAME} SET statement_timeout = '${STATEMENT_TIMEOUT_ESCAPED}';
+
+ALTER ROLE ${APP_ROLE} CONNECTION LIMIT ${CONNECTION_LIMIT};
+ALTER ROLE ${APP_ROLE} SET search_path = ${APP_SCHEMA}, pg_catalog;
+ALTER ROLE ${APP_ROLE} SET lock_timeout = '${LOCK_TIMEOUT_ESCAPED}';
+ALTER ROLE ${APP_ROLE} SET idle_in_transaction_session_timeout = '${IDLE_IN_TX_TIMEOUT_ESCAPED}';
+"
+
+run_psql "${DATABASE_NAME}" "
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM ${ADMIN_USER};
+GRANT USAGE ON SCHEMA public TO ${ADMIN_USER};
+GRANT CREATE ON SCHEMA public TO ${ADMIN_USER};
+
+DO \$\$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.schemata
+    WHERE schema_name = '${APP_SCHEMA}'
+  ) THEN
+    EXECUTE 'CREATE SCHEMA ${APP_SCHEMA} AUTHORIZATION ${PLATFORM_OWNER_ROLE}';
+  END IF;
+END
+\$\$;
+
+ALTER SCHEMA ${APP_SCHEMA} OWNER TO ${PLATFORM_OWNER_ROLE};
+
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${APP_SCHEMA} FROM ${APP_ROLE};
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA ${APP_SCHEMA} FROM ${APP_ROLE};
+REVOKE GRANT OPTION FOR ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${APP_SCHEMA} FROM ${APP_ROLE};
+REVOKE GRANT OPTION FOR ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA ${APP_SCHEMA} FROM ${APP_ROLE};
+
+ALTER DEFAULT PRIVILEGES FOR ROLE ${PLATFORM_OWNER_ROLE} IN SCHEMA ${APP_SCHEMA}
+  REVOKE ALL ON TABLES FROM ${APP_ROLE};
+ALTER DEFAULT PRIVILEGES FOR ROLE ${PLATFORM_OWNER_ROLE} IN SCHEMA ${APP_SCHEMA}
+  REVOKE ALL ON SEQUENCES FROM ${APP_ROLE};
+ALTER DEFAULT PRIVILEGES FOR ROLE ${PLATFORM_OWNER_ROLE} IN SCHEMA ${APP_SCHEMA}
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${APP_ROLE};
+ALTER DEFAULT PRIVILEGES FOR ROLE ${PLATFORM_OWNER_ROLE} IN SCHEMA ${APP_SCHEMA}
+  GRANT USAGE, SELECT ON SEQUENCES TO ${APP_ROLE};
+
+GRANT USAGE ON SCHEMA ${APP_SCHEMA} TO ${APP_ROLE};
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${APP_SCHEMA} TO ${APP_ROLE};
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA ${APP_SCHEMA} TO ${APP_ROLE};
+
+REVOKE GRANT OPTION FOR SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${APP_SCHEMA} FROM ${APP_ROLE};
+REVOKE GRANT OPTION FOR USAGE, SELECT ON ALL SEQUENCES IN SCHEMA ${APP_SCHEMA} FROM ${APP_ROLE};
+"
+
+cat <<EOF
+Tenant '${TENANT_KEY}' provisioned.
+
+Vault output contract:
+  path: tenants/${TENANT_KEY}/db
+  keys:
+    DATABASE_URL=postgresql://${APP_ROLE}:<redacted>@${ADMIN_HOST}:${ADMIN_PORT}/${DATABASE_NAME}
+    DB_HOST=${ADMIN_HOST}
+    DB_PORT=${ADMIN_PORT}
+    DB_NAME=${DATABASE_NAME}
+    DB_USER=${APP_ROLE}
+    DB_PASSWORD=<redacted>
+EOF


### PR DESCRIPTION
## Summary
- add a host-targeted tenant provisioning script for the external shared PostgreSQL service
- define the first formal provisioning workflow and Vault output contract
- align the repo docs with the new split between VM provisioning and PostgreSQL-internal provisioning

## Testing
- `bash -n scripts/provision_tenant.sh`
- started a throwaway `postgres:17` container on port `55432`
- ran `scripts/provision_tenant.sh` from the repo root against that host with a demo tenant/database/role
- reran the same provisioning command to confirm idempotency
- verified the demo tenant resolved to the `app` schema by default
- verified the demo tenant could not create a table in `public`
- stopped the throwaway container

## Notes
- this PR establishes the generic external-host provisioning model in `pg`
- `panchito` remains tracked separately as the first consumer in `#10`
- automatic Vault writes are still out of scope; this PR defines the output contract only

Closes #9
