### PR TITLE
Raise default tenant connection limit

### DIFF
--- a/docs/PROVISIONING.md
+++ b/docs/PROVISIONING.md
@@ -60,7 +60,7 @@ Optional inputs:
 - statement timeout, default `3s`
 - lock timeout, default `2s`
 - idle-in-transaction timeout, default `10s`
-- connection limit, default `2`
+- connection limit, default `10`
 
 ## Example
 
@@ -90,6 +90,10 @@ Against the shared host:
    - `connection_limit`
    - `lock_timeout`
    - `idle_in_transaction_session_timeout`
+
+The default connection limit is intentionally conservative, but it must still fit
+real process models. The original default of `2` was too low for `panchito`'s
+multi-worker runtime, so the v1 default is now `10`.
 7. Locks down `public` in the tenant database
 8. Ensures the tenant `app` schema exists and is owned by `platform_owner`
 9. Applies default privileges and runtime grants for tables and sequences

--- a/init/02_hardening.sql
+++ b/init/02_hardening.sql
@@ -101,7 +101,7 @@ GRANT USAGE ON SCHEMA app TO tenant_a_app;
 -----------------------------------------------------------------------
 
 ALTER ROLE tenant_a_app SET search_path = app;
-ALTER ROLE tenant_a_app CONNECTION LIMIT 2;
+ALTER ROLE tenant_a_app CONNECTION LIMIT 10;
 ALTER ROLE tenant_a_app SET lock_timeout = '2s';
 ALTER ROLE tenant_a_app SET idle_in_transaction_session_timeout = '10s';
 
@@ -147,7 +147,7 @@ REVOKE GRANT OPTION FOR USAGE, SELECT ON ALL SEQUENCES IN SCHEMA app FROM tenant
 GRANT USAGE ON SCHEMA app TO tenant_b_app;
 
 ALTER ROLE tenant_b_app SET search_path = app;
-ALTER ROLE tenant_b_app CONNECTION LIMIT 2;
+ALTER ROLE tenant_b_app CONNECTION LIMIT 10;
 ALTER ROLE tenant_b_app SET lock_timeout = '2s';
 ALTER ROLE tenant_b_app SET idle_in_transaction_session_timeout = '10s';
 
@@ -193,7 +193,7 @@ REVOKE GRANT OPTION FOR USAGE, SELECT ON ALL SEQUENCES IN SCHEMA app FROM tenant
 GRANT USAGE ON SCHEMA app TO tenant_c_app;
 
 ALTER ROLE tenant_c_app SET search_path = app;
-ALTER ROLE tenant_c_app CONNECTION LIMIT 2;
+ALTER ROLE tenant_c_app CONNECTION LIMIT 10;
 ALTER ROLE tenant_c_app SET lock_timeout = '2s';
 ALTER ROLE tenant_c_app SET idle_in_transaction_session_timeout = '10s';
 

--- a/scripts/provision_tenant.sh
+++ b/scripts/provision_tenant.sh
@@ -21,7 +21,7 @@ Optional:
   --statement-timeout <duration>               Default: 3s
   --lock-timeout <duration>                    Default: 2s
   --idle-in-tx-timeout <duration>              Default: 10s
-  --connection-limit <number>                  Default: 2
+  --connection-limit <number>                  Default: 10
   --sslmode <mode>                             Default: disable
 
 This script provisions one tenant database and login role on a shared PostgreSQL host.
@@ -42,7 +42,7 @@ APP_SCHEMA="app"
 STATEMENT_TIMEOUT="3s"
 LOCK_TIMEOUT="2s"
 IDLE_IN_TX_TIMEOUT="10s"
-CONNECTION_LIMIT="2"
+CONNECTION_LIMIT="10"
 SSLMODE="disable"
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary
- raise the default tenant role connection limit from `2` to `10`
- align the generic provisioning script, provisioning docs, and sample hardening SQL
- document the reason: `panchito`'s first real shared-PostgreSQL onboarding exceeded the original default

## Testing
- not run (configuration and documentation change only)
